### PR TITLE
Compatibility for newer mininet versions in fresh installs

### DIFF
--- a/versuch3/scripts/topology.py
+++ b/versuch3/scripts/topology.py
@@ -5,6 +5,7 @@ from mininet.cli import CLI
 from mininet.log import lg
 from mininet.topo import Topo
 from mininet.link import TCLink
+from mininet.node import OVSController
 
 
 class MyTopo(Topo):
@@ -61,7 +62,7 @@ def conf(network):
 
 def nettopo(**kwargs):
     topo = MyTopo()
-    return Mininet(topo=topo, link=TCLink, **kwargs)
+    return Mininet(topo=topo, link=TCLink, controller = OVSController, **kwargs)
 
 
 if __name__ == '__main__':

--- a/versuch4/scripts/mininet_1.py
+++ b/versuch4/scripts/mininet_1.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 from mininet_base import start
 

--- a/versuch4/scripts/mininet_2.py
+++ b/versuch4/scripts/mininet_2.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 from mininet_base import start
 

--- a/versuch4/scripts/mininet_3.py
+++ b/versuch4/scripts/mininet_3.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 from mininet_base import start
 

--- a/versuch4/scripts/mininet_base.py
+++ b/versuch4/scripts/mininet_base.py
@@ -6,6 +6,10 @@ from mininet.node import Node
 from mininet.topo import Topo
 from mininet.util import waitListening
 
+
+from mininet.node import OVSController
+
+
 class NetTopo(Topo):
     def __init__(self, loss):
         Topo.__init__(self)
@@ -47,7 +51,7 @@ def sshd(net):
 def start(loss):
     lg.setLogLevel('info')
     topo = NetTopo(loss=loss)
-    net = Mininet(topo=topo, link=TCLink)
+    net = Mininet(topo = topo, controller = OVSController)
 
     conf(net)
     sshd(net)


### PR DESCRIPTION
Updated to include the OVS Controller as the default openflow controller as newer versions of the mininet lib now require this option set explicitly in the constructor. 
Also updated the shebang to use python 3 path from env.

It now runs on both stable and unstable debian installs. 