### PR TITLE
Adding Docker Mail-Server

### DIFF
--- a/versuch1/aufgabenstellung.md
+++ b/versuch1/aufgabenstellung.md
@@ -1,52 +1,11 @@
 # Versuch 1 - Anwendungsschicht
 
 Zur Lösung dieses Versuchs steht ihnen neben einer virtuelle Maschine seit dem SS22 auch ein Docker-Container 
-zur Verfügung.
-Wir empfehlen ihnen dessen Nutzung, insofern Sie die Aufgaben Vor-Ort an einem Pool-Rechner lösen möchten.
-Innerhalb des Docker-Containers befindet sich ein Mail-Server der unter anderem den notwendigen Mail Transfer Agent 
+zur Verfügung. Wir empfehlen ihnen dessen Nutzung, insofern Sie die Aufgaben Vor-Ort an einem Pool-Rechner lösen möchten.
+Innerhalb des Docker-Containers befindet sich, ähnlich der virtuellen Maschine, ein Mail-Server der unter anderem den notwendigen Mail Transfer Agent 
 Postfix und Mail Delivery Agent Dovecot enthält.
-
-## Installation Docker / Docker Compose
-
-Prüfen Sie ob auf ihrem Rechner Docker installiert ist und installieren Sie es bei Bedarf
-```bash
-docker --version # Prüfe ob Docker schon installiert ist
-# Docker version 20.10.7, build 20.10.7-0ubuntu5~20.04.2
-sudo apt install docker.io # Installiere Docker bei Bedarf
-```
-
-Installieren Sie Docker Compose
-```bash
-# Download Docker Compose
-sudo curl -L "https://github.com/docker/compose/releases/download/1.29.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
-# Make its Binary executable
-sudo chmod +x /usr/local/bin/docker-compose
-# Show version if installed correctly
-docker-compose --version
-# docker-compose version 1.29.2, build 5becea4c
-```
-
-## Konfiguration des Mail-Servers
-
-Um den Mail-Server korrekt nutzen zu können, müssen Sie vor dessen Start noch dessen Konfiguration anpassen.
-Öffnen dafür zuerst die Datei "docker-compose.yml" und tragen Sie in Zeile 7 den Hostname ihres Rechners ein.
-Den Hostname erhalten sie z.B. mit diesem Befehl
-```bash
-hostname
-```
-
-## Starten des Mail-Servers
-
-Um den Mail-Server zu starten, führen Sie folgenden Befehl aus.
-```bash
-sudo docker-compose up
-```
-
-Um den Mail-Server zu stoppen, führen Sie folgenden Befehl aus.
-```bash
-sudo docker-compose down
-```
-
+Weitere Informationen zur Einrichtung und Nutzung, finden Sie in `/versuch1-docker/einrichtung.md`.
+Sollten Sie die virtuelle Maschine benutzen, können Sie hier direkt fortfahren.
 
 ## Anmeldeinformationen und MailDir-Ordner
 
@@ -69,9 +28,19 @@ Die zweite Aufgabe umfasst das Senden einer E-Mail mit Hilfe der Java Mail API. 
 Für diese Aufgabe können Sie `kn1lab/versuch1` in IntelliJ öffnen. 
 Die Vorlage für diese Aufgabe finden Sie in IntelliJ unter `versuch1/src/Send_Mail.java`.
 
-Der Mail-Server läuft auf `localhost`, d.h. die E-Mail-Adressen für Sender und Empfänger müssen auf `@localhost` enden. Da es auf dem Rechner (normalerweise) nur den Benutzer `labrat` gibt, sollten Sie die Nachricht an `labrat@localhost` senden. Um später erfolgreich eine Sitzung aufzubauen, benötigen Sie nur den Name des Hosts. Die E-Mail dürfen Sie direkt über den Code erzeugen.
+#### Falls Sie die virtuelle Maschine benutzen
+Der Mail-Server läuft auf `localhost`, d.h. die E-Mail-Adressen für Sender und Empfänger müssen auf `@localhost` enden. 
+Da es auf dem Rechner (normalerweise) nur den Benutzer `labrat` gibt, sollten Sie die Nachricht an `labrat@localhost` senden. 
+Um später erfolgreich eine Sitzung aufzubauen, benötigen Sie nur den Namen des Hosts. Die E-Mail dürfen Sie direkt über den Code erzeugen.
 
 Um zu kontrollieren, ob die E-Mail erfolgreich versendet wurde, kann im Ordner `/home/user/Maildir` im Unterordner `new` nachgeschaut werden. 
+
+#### Falls Sie Docker benutzen
+Der Mail-Server läuft auf `localhost`, allerdings müssen die E-Mail-Adressen für Sender und Empfänger auf `@my-hostname` enden.
+Die Benutzer sollten Sie während der Einrichtung der Laborumgebung (siehe `/versuch1-docker/einrichtung.md`) schon angelegt haben.
+Melden Sie sich unter der Nutzung der Java API mit einem der Benutzer an und Senden Sie eine Nachricht an einen anderen Benutzer.
+
+Um zu kontrollieren, ob die E-Mail erfolgreich versendet wurde, kann im Ordner `/versuch1/versuch1-docker/docker-data/dms/mail-data/<my-hostname>/<my-username>` im Unterordner `new` nachgeschaut werden.
 
 ## Aufgabe 3
 

--- a/versuch1/aufgabenstellung.md
+++ b/versuch1/aufgabenstellung.md
@@ -1,5 +1,53 @@
 # Versuch 1 - Anwendungsschicht
 
+Zur Lösung dieses Versuchs steht ihnen neben einer virtuelle Maschine seit dem SS22 auch ein Docker-Container 
+zur Verfügung.
+Wir empfehlen ihnen dessen Nutzung, insofern Sie die Aufgaben Vor-Ort an einem Pool-Rechner lösen möchten.
+Innerhalb des Docker-Containers befindet sich ein Mail-Server der unter anderem den notwendigen Mail Transfer Agent 
+Postfix und Mail Delivery Agent Dovecot enthält.
+
+## Installation Docker / Docker Compose
+
+Prüfen Sie ob auf ihrem Rechner Docker installiert ist und installieren Sie es bei Bedarf
+```bash
+docker --version # Prüfe ob Docker schon installiert ist
+# Docker version 20.10.7, build 20.10.7-0ubuntu5~20.04.2
+sudo apt install docker.io # Installiere Docker bei Bedarf
+```
+
+Installieren Sie Docker Compose
+```bash
+# Download Docker Compose
+sudo curl -L "https://github.com/docker/compose/releases/download/1.29.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+# Make its Binary executable
+sudo chmod +x /usr/local/bin/docker-compose
+# Show version if installed correctly
+docker-compose --version
+# docker-compose version 1.29.2, build 5becea4c
+```
+
+## Konfiguration des Mail-Servers
+
+Um den Mail-Server korrekt nutzen zu können, müssen Sie vor dessen Start noch dessen Konfiguration anpassen.
+Öffnen dafür zuerst die Datei "docker-compose.yml" und tragen Sie in Zeile 7 den Hostname ihres Rechners ein.
+Den Hostname erhalten sie z.B. mit diesem Befehl
+```bash
+hostname
+```
+
+## Starten des Mail-Servers
+
+Um den Mail-Server zu starten, führen Sie folgenden Befehl aus.
+```bash
+sudo docker-compose up
+```
+
+Um den Mail-Server zu stoppen, führen Sie folgenden Befehl aus.
+```bash
+sudo docker-compose down
+```
+
+
 ## Anmeldeinformationen und MailDir-Ordner
 
 Benutzername: `labrat`<br>

--- a/versuch1/versuch1-docker/docker-compose.yml
+++ b/versuch1/versuch1-docker/docker-compose.yml
@@ -1,0 +1,30 @@
+services:
+  mailserver:
+    image: docker.io/mailserver/docker-mailserver:latest
+    container_name: mailserver
+    # If the FQDN for your mail-server is only two labels (eg: example.com),
+    # you can assign this entirely to `hostname` and remove `domainname`.
+    hostname: kn1lab
+    domainname: localhost
+    env_file: mailserver.env
+    # More information about the mail-server ports:
+    # https://docker-mailserver.github.io/docker-mailserver/edge/config/security/understanding-the-ports/
+    # To avoid conflicts with yaml base-60 float, DO NOT remove the quotation marks.
+    ports:
+      - "25:25"    # SMTP  (explicit TLS => STARTTLS)
+      - "143:143"  # IMAP4 (explicit TLS => STARTTLS)
+      - "465:465"  # ESMTP (implicit TLS)
+      - "587:587"  # ESMTP (explicit TLS => STARTTLS)
+      - "993:993"  # IMAP4 (implicit TLS)
+    volumes:
+      - ./docker-data/dms/mail-data/:/var/mail/
+      - ./docker-data/dms/mail-state/:/var/mail-state/
+      - ./docker-data/dms/mail-logs/:/var/log/mail/
+      - ./docker-data/dms/config/:/tmp/docker-mailserver/
+      - /etc/localtime:/etc/localtime:ro
+    restart: always
+    stop_grace_period: 1m
+    cap_add:
+      - NET_ADMIN
+      - SYS_PTRACE
+

--- a/versuch1/versuch1-docker/docker-compose.yml
+++ b/versuch1/versuch1-docker/docker-compose.yml
@@ -16,6 +16,7 @@ services:
       - "465:465"  # ESMTP (implicit TLS)
       - "587:587"  # ESMTP (explicit TLS => STARTTLS)
       - "993:993"  # IMAP4 (implicit TLS)
+      - "110:110"  # POP3
     volumes:
       - ./docker-data/dms/mail-data/:/var/mail/
       - ./docker-data/dms/mail-state/:/var/mail-state/

--- a/versuch1/versuch1-docker/einrichtung.md
+++ b/versuch1/versuch1-docker/einrichtung.md
@@ -1,0 +1,65 @@
+# Einrichtung der Laborumgebung unter Nutzung von Docker
+Hier wird Ihnen die Einrichtung der Laborumgebung beschrieben, falls Sie statt der virtuellen Maschine einen Docker Container
+verwenden möchten. Dies bietet sich an, falls Sie die Aufgabenstellung an einem Pool-Rechner lösen möchten.
+
+## Installation Docker / Docker Compose
+
+Prüfen Sie ob auf ihrem Rechner Docker installiert ist und installieren Sie es bei Bedarf
+```bash
+docker --version # Prüfe ob Docker schon installiert ist
+# Docker version 20.10.7, build 20.10.7-0ubuntu5~20.04.2
+sudo apt install docker.io # Installiere Docker bei Bedarf
+```
+
+Installieren Sie Docker Compose
+```bash
+# Download Docker Compose
+sudo curl -L "https://github.com/docker/compose/releases/download/1.29.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
+# Make its Binary executable
+sudo chmod +x /usr/local/bin/docker-compose
+# Show version if installed correctly
+docker-compose --version
+# docker-compose version 1.29.2, build 5becea4c
+```
+
+## Konfiguration des Mail-Servers
+
+Um den Mail-Server korrekt nutzen zu können, müssen Sie vor dessen Start noch dessen Konfiguration anpassen.
+Öffnen dafür zuerst die Datei `docker-compose.yml` und tragen Sie in Zeile 7 den Hostname ihres Rechners ein.
+Den Hostname erhalten sie z.B. mit diesem Befehl
+```bash
+hostname
+```
+
+## Erstmaliger Start
+
+Um den Mail-Server zu starten und zu stoppen, können Sie folgende Befehle ausführen.
+```bash
+sudo docker-compose up -d # Start the Mail-Server
+sudo docker-compose down # Stop the Mail-Server
+```
+Bei dem erstmaligen Start wird für Sie ein neuer Ordner `docker-data` angelegt werden, in dem sich unter anderem die Verzeichnisstruktur
+MailDir befindet, und der Server wird in einen Fehlerzustand übergehen, da noch keine Benutzer angelegt wurden.
+Sobald `/versuch1/versuch1-docker/docker-data` angelegt wurde, müssen Sie den Mail-Server noch einmal stoppen und mit dem Anlegen von Benutzern fortfahren.
+
+## Anlegen von Benutzern
+Um Benutzer anzulegen, steht ihnen das Script `/versuch1/versuch1-docker/setup.sh` zur Verfügung welches ihnen folgende
+Befehle anbietet.
+```bash
+# Lege Benutzer an
+sudo ./setup.sh email add <my-username@my-hostname> <my-password>
+# Bsp. : sudo ./setup.sh email add oliver.waldhorst@kn1lab h-ka2022
+# Lösche Benutzer
+sudo ./setup.sh email del <my-username@my-hostname>
+# Bsp. : sudo ./setup.sh email del oliver.waldhorst@kn1lab
+```
+Legen Sie zwei Benutzer an, die sich später E-Mails senden. Den Namen und das Passwort können Sie frei wählen, bitte denken Sie
+aber daran, nach dem `@` ihren Hostname zu verwenden, den Sie während der Konfiguration schon herausgefunden haben.
+
+## Letzt Schritte
+Nachdem Sie zwei Benutzer angelegt haben, sollten Sie in `/versuch1/versuch1-docker/docker-data/dms/mail-data/<my-hostname>`
+zwei Ordner sehen, die den Namen ihrer Benutzer entsprechen. In diesen Ordnern finden Sie später die E-Mails der Benutzer innerhalb
+der schon vorgestellten Unterordner `cur`, `tmp` und `new` der MailDir Struktur.
+
+Sie können nun den Mail-Server starten und mit der Lösung der Aufgaben fortfahren. Bitte denken Sie daran, diesen nachdem Sie fertig sind
+wieder zu stoppen!

--- a/versuch1/versuch1-docker/mailserver.env
+++ b/versuch1/versuch1-docker/mailserver.env
@@ -1,0 +1,534 @@
+# -----------------------------------------------
+# --- Mailserver Environment Variables ----------
+# -----------------------------------------------
+
+# DOCUMENTATION FOR THESE VARIABLES IS FOUND UNDER
+# https://docker-mailserver.github.io/docker-mailserver/edge/config/environment/
+
+# -----------------------------------------------
+# --- General Section ---------------------------
+# -----------------------------------------------
+
+# empty => uses the `hostname` command to get the mail server's canonical hostname
+# => Specify a fully-qualified domainname to serve mail for.  This is used for many of the config features so if you can't set your hostname (e.g. you're in a container platform that doesn't let you) specify it in this environment variable.
+OVERRIDE_HOSTNAME=
+
+# (deprecated: use LOG_LEVEL instead)
+# 0 => Debug disabled
+# 1 => Enables debug on startup
+DMS_DEBUG=0
+
+# Set the log level for DMS.
+# This is mostly relevant for container startup scripts and change detection event feedback.
+#
+# Valid values (in order of increasing verbosity) are: `error`, `warn`, `info`, `debug` and `trace`.
+# The default log level is `info`.
+LOG_LEVEL=info
+
+# critical => Only show critical messages
+# error => Only show erroneous output
+# **warn** => Show warnings
+# info => Normal informational output
+# debug => Also show debug messages
+SUPERVISOR_LOGLEVEL=
+
+# 0 => mail state in default directories
+# 1 => consolidate all states into a single directory (`/var/mail-state`) to allow persistence using docker volumes
+ONE_DIR=1
+
+# empty => postmaster@domain.com
+# => Specify the postmaster address
+POSTMASTER_ADDRESS=
+
+# Check for updates on container start and then once a day
+# If an update is available, a mail is sent to POSTMASTER_ADDRESS
+# 0 => Update check disabled
+# 1 => Update check enabled
+ENABLE_UPDATE_CHECK=1
+
+# Customize the update check interval.
+# Number + Suffix. Suffix must be 's' for seconds, 'm' for minutes, 'h' for hours or 'd' for days.
+UPDATE_CHECK_INTERVAL=1d
+
+# Set different options for mynetworks option (can be overwrite in postfix-main.cf)
+# **WARNING**: Adding the docker network's gateway to the list of trusted hosts, e.g. using the `network` or
+# `connected-networks` option, can create an open relay
+# https://github.com/docker-mailserver/docker-mailserver/issues/1405#issuecomment-590106498
+# The same can happen for rootless podman. To prevent this, set the value to "none" or configure slirp4netns
+# https://github.com/docker-mailserver/docker-mailserver/issues/2377
+#
+# none => Explicitly force authentication
+# container => Container IP address only
+# host => Add docker container network (ipv4 only)
+# network => Add all docker container networks (ipv4 only)
+# connected-networks => Add all connected docker networks (ipv4 only)
+PERMIT_DOCKER=none
+
+# In case you network interface differs from 'eth0', e.g. when you are using HostNetworking in Kubernetes,
+# you can set NETWORK_INTERFACE to whatever interface you want. This interface will then be used.
+#  - **empty** => eth0
+NETWORK_INTERFACE=
+
+# empty => modern
+# modern => Enables TLSv1.2 and modern ciphers only. (default)
+# intermediate => Enables TLSv1, TLSv1.1 and TLSv1.2 and broad compatibility ciphers.
+TLS_LEVEL=
+
+# Configures the handling of creating mails with forged sender addresses.
+#
+# empty => (not recommended, but default for backwards compatibility reasons)
+#           Mail address spoofing allowed. Any logged in user may create email messages with a forged sender address.
+#           See also https://en.wikipedia.org/wiki/Email_spoofing
+# 1 => (recommended) Mail spoofing denied. Each user may only send with his own or his alias addresses.
+#       Addresses with extension delimiters(http://www.postfix.org/postconf.5.html#recipient_delimiter) are not able to send messages.
+SPOOF_PROTECTION=
+
+# Enables the Sender Rewriting Scheme. SRS is needed if your mail server acts as forwarder. See [postsrsd](https://github.com/roehling/postsrsd/blob/master/README.md#sender-rewriting-scheme-crash-course) for further explanation.
+#  - **0** => Disabled
+#  - 1 => Enabled
+ENABLE_SRS=0
+
+# 1 => Enables POP3 service
+# empty => disables POP3
+ENABLE_POP3=1
+ENABLE_CLAMAV=0
+
+# Amavis content filter (used for ClamAV & SpamAssassin)
+# 0 => Disabled
+# 1 => Enabled
+ENABLE_AMAVIS=0
+
+# -1/-2/-3 => Only show errors
+# **0**    => Show warnings
+# 1/2      => Show default informational output
+# 3/4/5    => log debug information (very verbose)
+AMAVIS_LOGLEVEL=0
+
+# This enables the [zen.spamhaus.org](https://www.spamhaus.org/zen/) DNS block list in postfix
+# and various [lists](https://github.com/docker-mailserver/docker-mailserver/blob/f7465a50888eef909dbfc01aff4202b9c7d8bc00/target/postfix/main.cf#L58-L66) in postscreen.
+# Note: Emails will be rejected, if they don't pass the block list checks!
+# **0** => DNS block lists are disabled
+# 1     => DNS block lists are enabled
+ENABLE_DNSBL=0
+
+# If you enable Fail2Ban, don't forget to add the following lines to your `docker-compose.yml`:
+#    cap_add:
+#      - NET_ADMIN
+# Otherwise, `iptables` won't be able to ban IPs.
+ENABLE_FAIL2BAN=0
+
+# Fail2Ban blocktype
+# drop   => drop packet (send NO reply)
+# reject => reject packet (send ICMP unreachable)
+FAIL2BAN_BLOCKTYPE=drop
+
+# 1 => Enables Managesieve on port 4190
+# empty => disables Managesieve
+ENABLE_MANAGESIEVE=
+
+# **enforce** => Allow other tests to complete. Reject attempts to deliver mail with a 550 SMTP reply, and log the helo/sender/recipient information. Repeat this test the next time the client connects.
+# drop => Drop the connection immediately with a 521 SMTP reply. Repeat this test the next time the client connects.
+# ignore => Ignore the failure of this test. Allow other tests to complete. Repeat this test the next time the client connects. This option is useful for testing and collecting statistics without blocking mail.
+POSTSCREEN_ACTION=enforce
+
+# empty => all daemons start
+# 1 => only launch postfix smtp
+SMTP_ONLY=
+
+# Please read [the SSL page in the documentation](https://docker-mailserver.github.io/docker-mailserver/edge/config/security/ssl) for more information.
+#
+# empty => SSL disabled
+# letsencrypt => Enables Let's Encrypt certificates
+# custom => Enables custom certificates
+# manual => Let's you manually specify locations of your SSL certificates for non-standard cases
+# self-signed => Enables self-signed certificates
+SSL_TYPE=
+
+# These are only supported with `SSL_TYPE=manual`.
+# Provide the path to your cert and key files that you've mounted access to within the container.
+SSL_CERT_PATH=
+SSL_KEY_PATH=
+# Optional: A 2nd certificate can be supported as fallback (dual cert support), eg ECDSA with an RSA fallback.
+# Useful for additional compatibility with older MTA and MUA (eg pre-2015).
+SSL_ALT_CERT_PATH=
+SSL_ALT_KEY_PATH=
+
+# Set how many days a virusmail will stay on the server before being deleted
+# empty => 7 days
+VIRUSMAILS_DELETE_DELAY=
+
+# This Option is activating the Usage of POSTFIX_DAGENT to specify a lmtp client different from default dovecot socket.
+# empty => disabled
+# 1 => enabled
+ENABLE_POSTFIX_VIRTUAL_TRANSPORT=
+
+# Enabled by ENABLE_POSTFIX_VIRTUAL_TRANSPORT. Specify the final delivery of postfix
+#
+# empty => fail
+# `lmtp:unix:private/dovecot-lmtp` (use socket)
+# `lmtps:inet:<host>:<port>` (secure lmtp with starttls, take a look at https://sys4.de/en/blog/2014/11/17/sicheres-lmtp-mit-starttls-in-dovecot/)
+# `lmtp:<kopano-host>:2003` (use kopano as mailstore)
+# etc.
+POSTFIX_DAGENT=
+
+# Set the mailbox size limit for all users. If set to zero, the size will be unlimited (default).
+#
+# empty => 0
+POSTFIX_MAILBOX_SIZE_LIMIT=
+
+# See https://docker-mailserver.github.io/docker-mailserver/edge/config/user-management/accounts/#notes
+# 0 => Dovecot quota is disabled
+# 1 => Dovecot quota is enabled
+ENABLE_QUOTAS=1
+
+# Set the message size limit for all users. If set to zero, the size will be unlimited (not recommended!)
+#
+# empty => 10240000 (~10 MB)
+POSTFIX_MESSAGE_SIZE_LIMIT=
+
+# Mails larger than this limit won't be scanned.
+# ClamAV must be enabled (ENABLE_CLAMAV=1) for this.
+#
+# empty => 25M (25 MB)
+CLAMAV_MESSAGE_SIZE_LIMIT=
+
+# Enables regular pflogsumm mail reports.
+# This is a new option. The old REPORT options are still supported for backwards compatibility. If this is not set and reports are enabled with the old options, logrotate will be used.
+#
+# not set => No report
+# daily_cron => Daily report for the previous day
+# logrotate => Full report based on the mail log when it is rotated
+PFLOGSUMM_TRIGGER=
+
+# Recipient address for pflogsumm reports.
+#
+# not set => Use REPORT_RECIPIENT or POSTMASTER_ADDRESS
+# => Specify the recipient address(es)
+PFLOGSUMM_RECIPIENT=
+
+# Sender address (`FROM`) for pflogsumm reports if pflogsumm reports are enabled.
+#
+# not set => Use REPORT_SENDER
+# => Specify the sender address
+PFLOGSUMM_SENDER=
+
+# Interval for logwatch report.
+#
+# none => No report is generated
+# daily => Send a daily report
+# weekly => Send a report every week
+LOGWATCH_INTERVAL=
+
+# Recipient address for logwatch reports if they are enabled.
+#
+# not set => Use REPORT_RECIPIENT or POSTMASTER_ADDRESS
+# => Specify the recipient address(es)
+LOGWATCH_RECIPIENT=
+
+# Sender address (`FROM`) for logwatch reports if logwatch reports are enabled.
+#
+# not set => Use REPORT_SENDER
+# => Specify the sender address
+LOGWATCH_SENDER=
+
+# Defines who receives reports if they are enabled.
+# **empty** => ${POSTMASTER_ADDRESS}
+# => Specify the recipient address
+REPORT_RECIPIENT=
+
+# Defines who sends reports if they are enabled.
+# **empty** => mailserver-report@${DOMAINNAME}
+# => Specify the sender address
+REPORT_SENDER=
+
+# Changes the interval in which log files are rotated
+# **weekly** => Rotate log files weekly
+# daily => Rotate log files daily
+# monthly => Rotate log files monthly
+#
+# Note: This Variable actually controls logrotate inside the container
+# and rotates the log files depending on this setting. The main log output is
+# still available in its entirety via `docker logs mail` (Or your
+# respective container name). If you want to control logrotation for
+# the Docker-generated logfile see:
+# https://docs.docker.com/config/containers/logging/configure/
+#
+# Note: This variable can also determine the interval for Postfix's log summary reports, see [`PFLOGSUMM_TRIGGER`](#pflogsumm_trigger).
+LOGROTATE_INTERVAL=weekly
+
+# Choose TCP/IP protocols for postfix to use
+# **all** => All possible protocols.
+# ipv4 => Use only IPv4 traffic. Most likely you want this behind Docker.
+# ipv6 => Use only IPv6 traffic.
+#
+# Note: More details at http://www.postfix.org/postconf.5.html#inet_protocols
+POSTFIX_INET_PROTOCOLS=all
+
+# Choose TCP/IP protocols for dovecot to use
+# **all** => Listen on all interfaces
+# ipv4 => Listen only on IPv4 interfaces. Most likely you want this behind Docker.
+# ipv6 => Listen only on IPv6 interfaces.
+#
+# Note: More information at https://dovecot.org/doc/dovecot-example.conf
+DOVECOT_INET_PROTOCOLS=all
+
+# -----------------------------------------------
+# --- SpamAssassin Section ----------------------
+# -----------------------------------------------
+
+ENABLE_SPAMASSASSIN=0
+
+# deliver spam messages in the inbox (eventually tagged using SA_SPAM_SUBJECT)
+SPAMASSASSIN_SPAM_TO_INBOX=1
+
+# KAM is a 3rd party SpamAssassin ruleset, provided by the McGrail Foundation.
+# If SpamAssassin is enabled, KAM can be used in addition to the default ruleset.
+# - **0** => KAM disabled
+# - 1 => KAM enabled
+#
+# Note: only has an effect if `ENABLE_SPAMASSASSIN=1`
+ENABLE_SPAMASSASSIN_KAM=0
+
+# spam messages will be moved in the Junk folder (SPAMASSASSIN_SPAM_TO_INBOX=1 required)
+MOVE_SPAM_TO_JUNK=1
+
+# add spam info headers if at, or above that level:
+SA_TAG=2.0
+
+# add 'spam detected' headers at that level
+SA_TAG2=6.31
+
+# triggers spam evasive actions
+SA_KILL=6.31
+
+# add tag to subject if spam detected
+SA_SPAM_SUBJECT=***SPAM*****
+
+# -----------------------------------------------
+# --- Fetchmail Section -------------------------
+# -----------------------------------------------
+
+ENABLE_FETCHMAIL=0
+
+# The interval to fetch mail in seconds
+FETCHMAIL_POLL=300
+
+# -----------------------------------------------
+# --- LDAP Section ------------------------------
+# -----------------------------------------------
+
+# A second container for the ldap service is necessary (i.e. https://github.com/osixia/docker-openldap)
+# For preparing the ldap server to use in combination with this container this article may be helpful: http://acidx.net/wordpress/2014/06/installing-a-mailserver-with-postfix-dovecot-sasl-ldap-roundcube/
+
+# empty => LDAP authentification is disabled
+# 1 => LDAP authentification is enabled
+ENABLE_LDAP=
+
+# empty => no
+# yes => LDAP over TLS enabled for Postfix
+LDAP_START_TLS=
+
+# If you going to use the mailserver in combination with docker-compose you can set the service name here
+# empty => mail.domain.com
+# Specify the dns-name/ip-address where the ldap-server
+LDAP_SERVER_HOST=
+
+# empty => ou=people,dc=domain,dc=com
+# => e.g. LDAP_SEARCH_BASE=dc=mydomain,dc=local
+LDAP_SEARCH_BASE=
+
+# empty => cn=admin,dc=domain,dc=com
+# => take a look at examples of SASL_LDAP_BIND_DN
+LDAP_BIND_DN=
+
+# empty** => admin
+# => Specify the password to bind against ldap
+LDAP_BIND_PW=
+
+# e.g. `"(&(mail=%s)(mailEnabled=TRUE))"`
+# => Specify how ldap should be asked for users
+LDAP_QUERY_FILTER_USER=
+
+# e.g. `"(&(mailGroupMember=%s)(mailEnabled=TRUE))"`
+# => Specify how ldap should be asked for groups
+LDAP_QUERY_FILTER_GROUP=
+
+# e.g. `"(&(mailAlias=%s)(mailEnabled=TRUE))"`
+# => Specify how ldap should be asked for aliases
+LDAP_QUERY_FILTER_ALIAS=
+
+# e.g. `"(&(|(mail=*@%s)(mailalias=*@%s)(mailGroupMember=*@%s))(mailEnabled=TRUE))"`
+# => Specify how ldap should be asked for domains
+LDAP_QUERY_FILTER_DOMAIN=
+
+# -----------------------------------------------
+# --- Dovecot Section ---------------------------
+# -----------------------------------------------
+
+# empty => no
+# yes => LDAP over TLS enabled for Dovecot
+DOVECOT_TLS=
+
+# e.g. `"(&(objectClass=PostfixBookMailAccount)(uniqueIdentifier=%n))"`
+DOVECOT_USER_FILTER=
+
+# e.g. `"(&(objectClass=PostfixBookMailAccount)(uniqueIdentifier=%n))"`
+DOVECOT_PASS_FILTER=
+
+# Define the mailbox format to be used
+# default is maildir, supported values are: sdbox, mdbox, maildir
+DOVECOT_MAILBOX_FORMAT=maildir
+
+# empty => no
+# yes => Allow bind authentication for LDAP
+# https://wiki.dovecot.org/AuthDatabase/LDAP/AuthBinds
+DOVECOT_AUTH_BIND=
+
+# -----------------------------------------------
+# --- Postgrey Section --------------------------
+# -----------------------------------------------
+
+ENABLE_POSTGREY=0
+# greylist for N seconds
+POSTGREY_DELAY=300
+# delete entries older than N days since the last time that they have been seen
+POSTGREY_MAX_AGE=35
+# response when a mail is greylisted
+POSTGREY_TEXT="Delayed by Postgrey"
+# whitelist host after N successful deliveries (N=0 to disable whitelisting)
+POSTGREY_AUTO_WHITELIST_CLIENTS=5
+
+# -----------------------------------------------
+# --- SASL Section ------------------------------
+# -----------------------------------------------
+
+ENABLE_SASLAUTHD=0
+
+# empty => pam
+# `ldap` => authenticate against ldap server
+# `shadow` => authenticate against local user db
+# `mysql` => authenticate against mysql db
+# `rimap` => authenticate against imap server
+# Note: can be a list of mechanisms like pam ldap shadow
+SASLAUTHD_MECHANISMS=
+
+# empty => None
+# e.g. with SASLAUTHD_MECHANISMS rimap you need to specify the ip-address/servername of the imap server  ==> xxx.xxx.xxx.xxx
+SASLAUTHD_MECH_OPTIONS=
+
+# empty => Use value of LDAP_SERVER_HOST
+# Note: since version 10.0.0, you can specify a protocol here (like ldaps://); this deprecates SASLAUTHD_LDAP_SSL.
+SASLAUTHD_LDAP_SERVER=
+
+# empty => Use value of LDAP_BIND_DN
+# specify an object with priviliges to search the directory tree
+# e.g. active directory: SASLAUTHD_LDAP_BIND_DN=cn=Administrator,cn=Users,dc=mydomain,dc=net
+# e.g. openldap: SASLAUTHD_LDAP_BIND_DN=cn=admin,dc=mydomain,dc=net
+SASLAUTHD_LDAP_BIND_DN=
+
+# empty => Use value of LDAP_BIND_PW
+SASLAUTHD_LDAP_PASSWORD=
+
+# empty => Use value of LDAP_SEARCH_BASE
+# specify the search base
+SASLAUTHD_LDAP_SEARCH_BASE=
+
+# empty => default filter `(&(uniqueIdentifier=%u)(mailEnabled=TRUE))`
+# e.g. for active directory: `(&(sAMAccountName=%U)(objectClass=person))`
+# e.g. for openldap: `(&(uid=%U)(objectClass=person))`
+SASLAUTHD_LDAP_FILTER=
+
+# empty => no
+# yes => LDAP over TLS enabled for SASL
+# If set to yes, the protocol in SASLAUTHD_LDAP_SERVER must be ldap:// or missing.
+SASLAUTHD_LDAP_START_TLS=
+
+# empty => no
+# yes => Require and verify server certificate
+# If yes you must/could specify SASLAUTHD_LDAP_TLS_CACERT_FILE or SASLAUTHD_LDAP_TLS_CACERT_DIR.
+SASLAUTHD_LDAP_TLS_CHECK_PEER=
+
+# File containing CA (Certificate Authority) certificate(s).
+# empty => Nothing is added to the configuration
+# Any value => Fills the `ldap_tls_cacert_file` option
+SASLAUTHD_LDAP_TLS_CACERT_FILE=
+
+# Path to directory with CA (Certificate Authority) certificates.
+# empty => Nothing is added to the configuration
+# Any value => Fills the `ldap_tls_cacert_dir` option
+SASLAUTHD_LDAP_TLS_CACERT_DIR=
+
+# Specify what password attribute to use for password verification.
+# empty => Nothing is added to the configuration but the documentation says it is `userPassword` by default.
+# Any value => Fills the `ldap_password_attr` option
+SASLAUTHD_LDAP_PASSWORD_ATTR=
+
+# empty => No sasl_passwd will be created
+# string => `/etc/postfix/sasl_passwd` will be created with the string as password
+SASL_PASSWD=
+
+# empty => `bind` will be used as a default value
+# `fastbind` => The fastbind method is used
+# `custom` => The custom method uses userPassword attribute to verify the password
+SASLAUTHD_LDAP_AUTH_METHOD=
+
+# Specify the authentication mechanism for SASL bind
+# empty => Nothing is added to the configuration
+# Any value => Fills the `ldap_mech` option
+SASLAUTHD_LDAP_MECH=
+
+# -----------------------------------------------
+# --- SRS Section -------------------------------
+# -----------------------------------------------
+
+# envelope_sender => Rewrite only envelope sender address (default)
+# header_sender => Rewrite only header sender (not recommended)
+# envelope_sender,header_sender => Rewrite both senders
+# An email has an "envelope" sender (indicating the sending server) and a
+# "header" sender (indicating who sent it). More strict SPF policies may require
+# you to replace both instead of just the envelope sender.
+SRS_SENDER_CLASSES=envelope_sender
+
+# empty => Envelope sender will be rewritten for all domains
+# provide comma separated list of domains to exclude from rewriting
+SRS_EXCLUDE_DOMAINS=
+
+# empty => generated when the image is built
+# provide a secret to use in base64
+# you may specify multiple keys, comma separated. the first one is used for
+# signing and the remaining will be used for verification. this is how you
+# rotate and expire keys
+SRS_SECRET=
+
+# -----------------------------------------------
+# --- Default Relay Host Section ----------------
+# -----------------------------------------------
+
+# Setup relaying all mail through a default relay host
+#
+# empty => don't configure default relay host
+# default host and optional port to relay all mail through
+DEFAULT_RELAY_HOST=
+
+# -----------------------------------------------
+# --- Multi-Domain Relay Section ----------------
+# -----------------------------------------------
+
+# Setup relaying for multiple domains based on the domain name of the sender
+# optionally uses usernames and passwords in postfix-sasl-password.cf and relay host mappings in postfix-relaymap.cf
+#
+# empty => don't configure relay host
+# default host to relay mail through
+RELAY_HOST=
+
+# empty => 25
+# default port to relay mail
+RELAY_PORT=25
+
+# empty => no default
+# default relay username (if no specific entry exists in postfix-sasl-password.cf)
+RELAY_USER=
+
+# empty => no default
+# password for default relay user
+RELAY_PASSWORD=

--- a/versuch1/versuch1-docker/setup.sh
+++ b/versuch1/versuch1-docker/setup.sh
@@ -1,0 +1,239 @@
+#! /bin/bash
+
+# version   v1.0.0
+# executed  manually / via Make
+# task      wrapper for various setup scripts
+
+CONFIG_PATH=
+CONTAINER_NAME=
+CRI=
+DEFAULT_CONFIG_PATH=
+DESIRED_CONFIG_PATH=
+DIR="$(pwd)"
+DMS_CONFIG='/tmp/docker-mailserver'
+IMAGE_NAME=
+DEFAULT_IMAGE_NAME='docker.io/mailserver/docker-mailserver:latest'
+INFO=
+PODMAN_ROOTLESS=false
+USE_SELINUX=
+USE_TTY=
+VOLUME=
+
+RED="\e[31m\e[1m"
+WHITE="\e[37m"
+ORANGE="\e[38;5;214m"
+LBLUE="\e[94m"
+RESET="\e[0m"
+
+set -euEo pipefail
+shopt -s inherit_errexit
+trap '__err "${BASH_SOURCE}" "${FUNCNAME[0]:-?}" "${BASH_COMMAND:-?}" "${LINENO:-?}" "${?:-?}"' ERR
+
+function __err
+{
+  [[ ${5} -gt 1 ]] && exit 1
+
+  local ERR_MSG="\n--- ${RED}UNCHECKED ERROR${RESET}"
+  ERR_MSG+="\n  - script    = ${1}"
+  ERR_MSG+="\n  - function  = ${2}"
+  ERR_MSG+="\n  - command   = ${3}"
+  ERR_MSG+="\n  - line      = ${4}"
+  ERR_MSG+="\n  - exit code = ${5}"
+  ERR_MSG+='\n\nThis should not have happened. Please file a bug report.\n'
+
+  echo -e "${ERR_MSG}"
+}
+
+function _show_local_usage
+{
+  # shellcheck disable=SC2059
+  printf "${ORANGE}OPTIONS${RESET}
+    ${LBLUE}Config path, container or image adjustments${RESET}
+        -i IMAGE_NAME
+            Provides the name of the 'docker-mailserver' image. The default value is
+            '${WHITE}${DEFAULT_IMAGE_NAME}${RESET}'
+
+        -c CONTAINER_NAME
+            Provides the name of the running container.
+
+        -p PATH
+            Provides the local path of the config folder to the temporary container instance.
+            Does not work if an existing a 'docker-mailserver' container is already running.
+
+    ${LBLUE}SELinux${RESET}
+        -z
+            Allows container access to the bind mount content that is shared among
+            multiple containers on a SELinux-enabled host.
+
+        -Z
+            Allows container access to the bind mount content that is private and
+            unshared with other containers on a SELinux-enabled host.
+
+    ${LBLUE}Podman${RESET}
+        -R
+            Accept running in Podman rootless mode. Ignored when using Docker / Docker Compose.
+
+"
+
+  [[ ${1:-} == 'no-exit' ]] && return 0
+
+  # shellcheck disable=SC2059
+  printf "${ORANGE}EXIT STATUS${RESET}
+    Exit status is 0 if the command was successful. If there was an unexpected error, an error
+    message is shown describing the error. In case of an error, the script will exit with exit
+    status 1.
+
+"
+}
+
+function _get_absolute_script_directory
+{
+  if dirname "$(readlink -f "${0}")" &>/dev/null
+  then
+    DIR="$(dirname "$(readlink -f "${0}")")"
+  elif realpath -e -L "${0}" &>/dev/null
+  then
+    DIR="$(realpath -e -L "${0}")"
+    DIR="${DIR%/setup.sh}"
+  fi
+}
+
+function _set_default_config_path
+{
+  if [[ -d "${DIR}/config" ]]
+  then
+    # legacy path (pre v10.2.0)
+    DEFAULT_CONFIG_PATH="${DIR}/config"
+  else
+    DEFAULT_CONFIG_PATH="${DIR}/docker-data/dms/config"
+  fi
+}
+
+function _handle_config_path
+{
+  if [[ -z ${DESIRED_CONFIG_PATH} ]]
+  then
+    # no desired config path
+    if [[ -n ${CONTAINER_NAME} ]]
+    then
+      VOLUME=$(${CRI} inspect "${CONTAINER_NAME}" \
+        --format="{{range .Mounts}}{{ println .Source .Destination}}{{end}}" | \
+        grep "${DMS_CONFIG}$" 2>/dev/null || :)
+    fi
+
+    if [[ -n ${VOLUME} ]]
+    then
+      CONFIG_PATH=$(echo "${VOLUME}" | awk '{print $1}')
+    fi
+
+    if [[ -z ${CONFIG_PATH} ]]
+    then
+      CONFIG_PATH=${DEFAULT_CONFIG_PATH}
+    fi
+  else
+    CONFIG_PATH=${DESIRED_CONFIG_PATH}
+  fi
+}
+
+function _run_in_new_container
+{
+  # start temporary container with specified image
+  if ! ${CRI} history -q "${IMAGE_NAME}" &>/dev/null
+  then
+    echo "Image '${IMAGE_NAME}' not found. Pulling ..."
+    ${CRI} pull "${IMAGE_NAME}"
+  fi
+
+  ${CRI} run --rm "${USE_TTY}" \
+    -v "${CONFIG_PATH}:${DMS_CONFIG}${USE_SELINUX}" \
+    "${IMAGE_NAME}" "${@}"
+}
+
+function _main
+{
+  _get_absolute_script_directory
+  _set_default_config_path
+
+  local OPTIND
+  while getopts ":c:i:p:zZR" OPT
+  do
+    case ${OPT} in
+      ( i )     IMAGE_NAME="${OPTARG}"     ;;
+      ( z | Z ) USE_SELINUX=":${OPT}"      ;;
+      ( c )     CONTAINER_NAME="${OPTARG}" ;;
+      ( R )     PODMAN_ROOTLESS=true       ;;
+      ( p )
+        case "${OPTARG}" in
+          ( /* ) DESIRED_CONFIG_PATH="${OPTARG}"        ;;
+          ( *  ) DESIRED_CONFIG_PATH="${DIR}/${OPTARG}" ;;
+        esac
+
+        if [[ ! -d ${DESIRED_CONFIG_PATH} ]]
+        then
+          echo "Specified directory '${DESIRED_CONFIG_PATH}' doesn't exist" >&2
+          exit 1
+        fi
+        ;;
+
+      ( * )
+        echo "Invalid option: '-${OPTARG}'" >&2
+        echo -e "Use './setup.sh help' to get a complete overview.\n" >&2
+        _show_local_usage 'no-exit'
+        exit 1
+        ;;
+
+    esac
+  done
+  shift $(( OPTIND - 1 ))
+
+  if command -v docker &>/dev/null
+  then
+    CRI=docker
+  elif command -v podman &>/dev/null
+  then
+    CRI=podman
+    if ! ${PODMAN_ROOTLESS} && [[ ${EUID} -ne 0 ]]
+    then
+      read -r -p "You are running Podman in rootless mode. Continue? [Y/n] "
+      [[ -n ${REPLY} ]] && [[ ${REPLY} =~ (n|N) ]] && exit 0
+    fi
+  else
+    echo 'No supported Container Runtime Interface detected.'
+    exit 1
+  fi
+
+  INFO=$(${CRI} ps --no-trunc --format "{{.Image}};{{.Names}}" --filter \
+    label=org.opencontainers.image.title="docker-mailserver" | tail -1)
+
+  CONTAINER_NAME=${INFO#*;}
+  [[ -z ${IMAGE_NAME} ]] && IMAGE_NAME=${INFO%;*}
+  if [[ -z ${IMAGE_NAME} ]]
+  then
+    IMAGE_NAME=${NAME:-${DEFAULT_IMAGE_NAME}}
+  fi
+
+  if test -t 0
+  then
+    USE_TTY="-it"
+  else
+    # GitHub Actions will fail (or really anything else
+    #   lacking an interactive tty) if we don't set a
+    #   value here; "-t" alone works for these cases.
+    USE_TTY="-t"
+  fi
+
+  _handle_config_path
+
+  if [[ -n ${CONTAINER_NAME} ]]
+  then
+    ${CRI} exec "${USE_TTY}" "${CONTAINER_NAME}" setup "${@}"
+  else
+    _run_in_new_container setup "${@}"
+  fi
+
+  [[ ${1} == 'help' ]] && _show_local_usage
+
+  return 0
+}
+
+_main "${@}"


### PR DESCRIPTION
1. Adds a folder "versuch1-docker" to task 1 which contains files to create a Mail-Server by using Docker Compose.
2. Adds documentation for students who want to use Docker-Compose instead of the virtual machine

Compared to the virtual machine, which might be unusable on pool computers, the Mail-Server container created by Docker Compose offers quicker installation, assuming students have basic command line knowledge, and way better performance than a virtual machine.